### PR TITLE
rename only the property name in a property assignment

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -178,7 +178,8 @@ export class Minifier {
       let childEnd = child.getEnd() - node.getStart();
       output += nodeText.substring(prevEnd, childStart);
       let childText = '';
-      if (renameIdent && child.kind === ts.SyntaxKind.Identifier) {
+      let hasName = (<any>node).name;
+      if (renameIdent && child.kind === ts.SyntaxKind.Identifier && hasName === child) {
         childText = this._renameIdent(child);
       } else {
         childText = this.visit(child);

--- a/src/main.ts
+++ b/src/main.ts
@@ -166,6 +166,7 @@ export class Minifier {
     // within the for loop below, and text from nodeText(0, prevEnd), including children text
     // that fall within the range, has already been copied over to output.
     let prevEnd = 0;
+    let nameChildNode = (<any>node).name;
     // Loop-invariant: prevEnd should always be less than or equal to the start position of
     // an unvisited child node because the text before a child's text must be copied over to
     // the new output before anything else.
@@ -178,8 +179,7 @@ export class Minifier {
       let childEnd = child.getEnd() - node.getStart();
       output += nodeText.substring(prevEnd, childStart);
       let childText = '';
-      let hasName = (<any>node).name;
-      if (renameIdent && child.kind === ts.SyntaxKind.Identifier && hasName === child) {
+      if (renameIdent && child === nameChildNode && child.kind === ts.SyntaxKind.Identifier) {
         childText = this._renameIdent(child);
       } else {
         childText = this.visit(child);

--- a/test/unit/main_test.ts
+++ b/test/unit/main_test.ts
@@ -80,6 +80,8 @@ describe('Visitor pattern', () => {
   it('renames identifiers of property declarations/assignments', () => {
     expectTranslate('var foo = { bar: { baz: 12; } }; foo.bar.baz;')
       .to.equal('var foo = { $: { _: 12; } }; foo.$._;');
+    expectTranslate('var x = "something"; var foo = { bar: { baz: x; } }; foo.bar.baz;')
+      .to.equal('var x = "something"; var foo = { $: { _: x; } }; foo.$._;');
     expectTranslate('class Foo {bar: string;} class Baz {bar: string;}')
       .to.equal('class Foo {$: string;} class Baz {$: string;}');
   });


### PR DESCRIPTION
Issue #41 

Only renames the `child` identifier if it is the same as the property `name` of its parent:

```js
interface PropertyDeclaration extends Declaration, ClassElement {
        name: DeclarationName;
        questionToken?: Node;
        type?: TypeNode;
        initializer?: Expression;
}

interface PropertyAssignment extends ObjectLiteralElement {
        _propertyAssignmentBrand: any;
        name: DeclarationName;
        questionToken?: Node;
        initializer: Expression;
}

interface FunctionDeclaration extends FunctionLikeDeclaration, Statement {
        name?: Identifier;
        body?: Block;
}

interface MethodDeclaration extends FunctionLikeDeclaration, ClassElement, ObjectLiteralElement {
        body?: Block;
}
```

