### PR TITLE
Property signature

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -144,6 +144,14 @@ export class Minifier {
 
         return this.contextEmit(node);
       }
+      case ts.SyntaxKind.PropertySignature: {
+        if (node.parent.kind === ts.SyntaxKind.TypeLiteral ||
+            node.parent.kind === ts.SyntaxKind.InterfaceDeclaration) {
+          let parentSymbol = this._typeChecker.getTypeAtLocation(node.parent).symbol;
+          return this.contextEmit(node, true);  // renameIdent is true for now
+        }
+        return this.contextEmit(node);
+      }
       // All have same wanted behavior.
       case ts.SyntaxKind.MethodDeclaration:
       case ts.SyntaxKind.PropertyAssignment:

--- a/src/main.ts
+++ b/src/main.ts
@@ -147,8 +147,8 @@ export class Minifier {
       case ts.SyntaxKind.PropertySignature: {
         if (node.parent.kind === ts.SyntaxKind.TypeLiteral ||
             node.parent.kind === ts.SyntaxKind.InterfaceDeclaration) {
-          let parentSymbol = this._typeChecker.getTypeAtLocation(node.parent).symbol;
-          return this.contextEmit(node, true);  // renameIdent is true for now
+          return this.contextEmit(
+              node, true);  // TODO: incorporate check for assignment to an external type
         }
         return this.contextEmit(node);
       }

--- a/test/unit/main_test.ts
+++ b/test/unit/main_test.ts
@@ -93,6 +93,10 @@ describe('Visitor pattern', () => {
     expectTranslate('interface LabelledValue { label: string; }')
         .to.equal('interface LabelledValue { $: string; }');
   });
+  it('renames properties on type literals', () => {
+    expectTranslate('function x(): { foo: string, bar: string } { return { foo: "foo", bar: "bar" }; }')
+      .to.equal('function x(): { $: string, _: string } { return { $: "foo", _: "bar" }; }');
+  });
   it('preserves spacing of original code', () => {
     expectTranslate('class Foo { constructor(public bar: string) {} }')
         .to.equal('class Foo { constructor(public $: string) {} }');

--- a/test/unit/main_test.ts
+++ b/test/unit/main_test.ts
@@ -87,13 +87,21 @@ describe('Visitor pattern', () => {
   });
   it('renames identifiers of property access expressions', () => {
     expectTranslate('class Foo { bar: string; constructor() {} baz() { this.bar = "hello"; } }')
-      .to.equal('class Foo { $: string; constructor() {} _() { this.$ = "hello"; } }');
+        .to.equal('class Foo { $: string; constructor() {} _() { this.$ = "hello"; } }');
+  });
+  it('renames properties on Interfaces', () => {
+    expectTranslate('interface LabelledValue { label: string; }')
+        .to.equal('interface LabelledValue { $: string; }');
   });
   it('preserves spacing of original code', () => {
-    expectTranslate('class Foo { constructor(public bar: string) {} }').to.equal('class Foo { constructor(public $: string) {} }');
-    expectTranslate('class Foo { constructor(private bar: string) {} }').to.equal('class Foo { constructor(private $: string) {} }');
-    expectTranslate('class Foo { constructor(protected bar: string) {} }').to.equal('class Foo { constructor(protected $: string) {} }');
-    expectTranslate('class Foo { constructor() {} private bar() {} }').to.equal('class Foo { constructor() {} private $() {} }');
+    expectTranslate('class Foo { constructor(public bar: string) {} }')
+        .to.equal('class Foo { constructor(public $: string) {} }');
+    expectTranslate('class Foo { constructor(private bar: string) {} }')
+        .to.equal('class Foo { constructor(private $: string) {} }');
+    expectTranslate('class Foo { constructor(protected bar: string) {} }')
+        .to.equal('class Foo { constructor(protected $: string) {} }');
+    expectTranslate('class Foo { constructor() {} private bar() {} }')
+        .to.equal('class Foo { constructor() {} private $() {} }');
   });
   it('throws an error when symbol information cannot be extracted from a property access expression',
      () => {

--- a/test/unit/main_test.ts
+++ b/test/unit/main_test.ts
@@ -94,8 +94,9 @@ describe('Visitor pattern', () => {
         .to.equal('interface LabelledValue { $: string; }');
   });
   it('renames properties on type literals', () => {
-    expectTranslate('function x(): { foo: string, bar: string } { return { foo: "foo", bar: "bar" }; }')
-      .to.equal('function x(): { $: string, _: string } { return { $: "foo", _: "bar" }; }');
+    expectTranslate(
+        'function x(): { foo: string, bar: string } { return { foo: "foo", bar: "bar" }; }')
+        .to.equal('function x(): { $: string, _: string } { return { $: "foo", _: "bar" }; }');
   });
   it('preserves spacing of original code', () => {
     expectTranslate('class Foo { constructor(public bar: string) {} }')


### PR DESCRIPTION
Adds a case for `PropertySignature`. (This does not incorporate the work we did today, so the checks for renaming will be added in with a subsequent PR).