### PR TITLE
Reference path

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -167,7 +167,6 @@ export class Minifier {
     // The indicies of nodeText range from 0 ... nodeText.length - 1. However, the start and end
     // positions of nodeText that .getStart() and .getEnd() return are relative to
     // the entire sourcefile.
-    // let nodeText = node.getText(); // DJJ
     let nodeText = node.getFullText();
     let children = node.getChildren();
     let output = '';
@@ -184,8 +183,8 @@ export class Minifier {
       // are relative to the indicies of the parent's text range (0 ... nodeText.length - 1), by
       // off-setting by the value of the parent's start position. Now childStart and childEnd
       // are relative to the range of (0 ... nodeText.length).
-      let childStart = child.getFullStart() - node.getFullStart(); // DJJ
-      let childEnd = child.getEnd() - node.getFullStart(); // DJJ
+      let childStart = child.getFullStart() - node.getFullStart();
+      let childEnd = child.getEnd() - node.getFullStart();
       output += nodeText.substring(prevEnd, childStart);
       let childText = '';
       if (renameIdent && child === nameChildNode && child.kind === ts.SyntaxKind.Identifier) {
@@ -216,17 +215,15 @@ export class Minifier {
   }
 
   // rename the identifier, but retain comments/spacing since we are using getFullText();
-  private _renameIdent(node: ts.Node) { 
+  private _renameIdent(node: ts.Node) {
     let fullText = node.getFullText();
-    let fullStart = node.getFullStart();;
+    let fullStart = node.getFullStart();
     let regStart = node.getStart() - fullStart;
     let preIdent = fullText.substring(0, regStart);
     return preIdent + this.renameProperty(node.getText());
   }
 
-  private _ident(node: ts.Node) { 
-    return node.getFullText();
-  }
+  private _ident(node: ts.Node) { return node.getFullText(); }
 
   // Alphabet: ['$', '_','0' - '9', 'a' - 'z', 'A' - 'Z'].
   // Generates the next char in the alphabet, starting from '$',
@@ -320,4 +317,3 @@ export class Minifier {
     }
   }
 }
-

--- a/src/main.ts
+++ b/src/main.ts
@@ -111,7 +111,7 @@ export class Minifier {
         let children = pae.getChildren();
 
         output += this.visit(pae.expression);
-        output += pae.dotToken.getText();
+        output += pae.dotToken.getFullText();
 
         // if LHS is a module, do not rename property name
         var lhsTypeSymbol = this._typeChecker.getTypeAtLocation(pae.expression).symbol;
@@ -167,7 +167,8 @@ export class Minifier {
     // The indicies of nodeText range from 0 ... nodeText.length - 1. However, the start and end
     // positions of nodeText that .getStart() and .getEnd() return are relative to
     // the entire sourcefile.
-    let nodeText = node.getText();
+    // let nodeText = node.getText(); // DJJ
+    let nodeText = node.getFullText();
     let children = node.getChildren();
     let output = '';
     // prevEnd is used to keep track of how much of nodeText has been copied over. It is updated
@@ -183,8 +184,8 @@ export class Minifier {
       // are relative to the indicies of the parent's text range (0 ... nodeText.length - 1), by
       // off-setting by the value of the parent's start position. Now childStart and childEnd
       // are relative to the range of (0 ... nodeText.length).
-      let childStart = child.getStart() - node.getStart();
-      let childEnd = child.getEnd() - node.getStart();
+      let childStart = child.getFullStart() - node.getFullStart(); // DJJ
+      let childEnd = child.getEnd() - node.getFullStart(); // DJJ
       output += nodeText.substring(prevEnd, childStart);
       let childText = '';
       if (renameIdent && child === nameChildNode && child.kind === ts.SyntaxKind.Identifier) {
@@ -214,9 +215,18 @@ export class Minifier {
     return exprSymbol;
   }
 
-  private _renameIdent(node: ts.Node) { return this.renameProperty(this._ident(node)); }
+  // rename the identifier, but retain comments/spacing since we are using getFullText();
+  private _renameIdent(node: ts.Node) { 
+    let fullText = node.getFullText();
+    let fullStart = node.getFullStart();;
+    let regStart = node.getStart() - fullStart;
+    let preIdent = fullText.substring(0, regStart);
+    return preIdent + this.renameProperty(node.getText());
+  }
 
-  private _ident(node: ts.Node) { return node.getText(); }
+  private _ident(node: ts.Node) { 
+    return node.getFullText();
+  }
 
   // Alphabet: ['$', '_','0' - '9', 'a' - 'z', 'A' - 'Z'].
   // Generates the next char in the alphabet, starting from '$',
@@ -310,3 +320,4 @@ export class Minifier {
     }
   }
 }
+

--- a/test/unit/main_test.ts
+++ b/test/unit/main_test.ts
@@ -132,8 +132,16 @@ describe('Full-text emit', () => {
         .to.equal('/// <reference path="../../typings/node/node.d.ts"/> var x = "hello";');
   });
   it('retains comments for a node', () => {
-    expectTranslate('// This comment should show up\n' + 'class Foo {\n' + '// these should also show up\n' + 'bar: string;\n' + '}')
-      .to.equal('// This comment should show up\n' + 'class Foo {\n' + '// these should also show up\n' + '$: string;\n' + '}');
+    expectTranslate('// This comment should show up\n' +
+                    'class Foo {\n' +
+                    '// these should also show up\n' +
+                    'bar: string;\n' +
+                    '}')
+        .to.equal('// This comment should show up\n' +
+                  'class Foo {\n' +
+                  '// these should also show up\n' +
+                  '$: string;\n' +
+                  '}');
   });
 });
 

--- a/test/unit/main_test.ts
+++ b/test/unit/main_test.ts
@@ -79,11 +79,11 @@ describe('Recognizes invalid TypeScript inputs', () => {
 describe('Visitor pattern', () => {
   it('renames identifiers of property declarations/assignments', () => {
     expectTranslate('var foo = { bar: { baz: 12; } }; foo.bar.baz;')
-      .to.equal('var foo = { $: { _: 12; } }; foo.$._;');
+        .to.equal('var foo = { $: { _: 12; } }; foo.$._;');
     expectTranslate('var x = "something"; var foo = { bar: { baz: x; } }; foo.bar.baz;')
-      .to.equal('var x = "something"; var foo = { $: { _: x; } }; foo.$._;');
+        .to.equal('var x = "something"; var foo = { $: { _: x; } }; foo.$._;');
     expectTranslate('class Foo {bar: string;} class Baz {bar: string;}')
-      .to.equal('class Foo {$: string;} class Baz {$: string;}');
+        .to.equal('class Foo {$: string;} class Baz {$: string;}');
   });
   it('renames identifiers of property access expressions', () => {
     expectTranslate('class Foo { bar: string; constructor() {} baz() { this.bar = "hello"; } }')
@@ -123,6 +123,13 @@ describe('Selective renaming', () => {
     expectTranslate('document.getElementById("foo");').to.equal('document.getElementById("foo");');
     expectTranslate('[1, 4, 9].map(Math.sqrt);').to.equal('[1, 4, 9].map(Math.sqrt);');
     expectTranslate('"hello".substring(0, 2);').to.equal('"hello".substring(0, 2);');
+  });
+});
+
+describe('Full-text emit', () => {
+  it('retains typings at the top of file', () => {
+    expectTranslate('/// <reference path="../../typings/node/node.d.ts"/> var x = "hello";')
+        .to.equal('/// <reference path="../../typings/node/node.d.ts"/> var x = "hello";');
   });
 });
 

--- a/test/unit/main_test.ts
+++ b/test/unit/main_test.ts
@@ -132,16 +132,8 @@ describe('Full-text emit', () => {
         .to.equal('/// <reference path="../../typings/node/node.d.ts"/> var x = "hello";');
   });
   it('retains comments for a node', () => {
-    expectTranslate(`// This comment should show up
-                        class Foo {
-                          // these should also show up
-                          bar: string;
-                        }`)
-        .to.equal(`// This comment should show up
-                        class Foo {
-                          // these should also show up
-                          $: string;
-                        }`);
+    expectTranslate('// This comment should show up\n' + 'class Foo {\n' + '// these should also show up\n' + 'bar: string;\n' + '}')
+      .to.equal('// This comment should show up\n' + 'class Foo {\n' + '// these should also show up\n' + '$: string;\n' + '}');
   });
 });
 

--- a/test/unit/main_test.ts
+++ b/test/unit/main_test.ts
@@ -131,6 +131,18 @@ describe('Full-text emit', () => {
     expectTranslate('/// <reference path="../../typings/node/node.d.ts"/> var x = "hello";')
         .to.equal('/// <reference path="../../typings/node/node.d.ts"/> var x = "hello";');
   });
+  it('retains comments for a node', () => {
+    expectTranslate(`// This comment should show up
+                        class Foo {
+                          // these should also show up
+                          bar: string;
+                        }`)
+        .to.equal(`// This comment should show up
+                        class Foo {
+                          // these should also show up
+                          $: string;
+                        }`);
+  });
 });
 
 describe('Next property name generation', () => {


### PR DESCRIPTION
Use `getFullStart()` to retain information in comments that might come before a node. 

Comments will be stripped later by `Uglify`.